### PR TITLE
Fix for logic error in onMouseDown() method

### DIFF
--- a/src/DragSelect.vue
+++ b/src/DragSelect.vue
@@ -60,7 +60,7 @@
     methods: {
       onMouseDown (event) {
         // Ignore right clicks
-        if (event.button === 2 || this.hasSelectorClass(event.target)) return
+        if (event.button === 2 && this.hasSelectorClass(event.target)) return
 
         // Register begin point
         this.mouseDown = true


### PR DESCRIPTION
Fix for logic error on onMouseDown() method

If I understood the idea correct, there should be `&&` instead of `||`, because with `&&` I'm able to make it start selection on the items with `selected-class`